### PR TITLE
Add directory selection for unzip output

### DIFF
--- a/src/app/components/file-unzip/file-unzip.component.ts
+++ b/src/app/components/file-unzip/file-unzip.component.ts
@@ -46,13 +46,14 @@ onDrop(evt: DragEvent) {
     (e.target as HTMLInputElement).value = '';
   }
 
-  private process(files: File[]) {
+  private async process(files: File[]) {
     const invalid = files.filter(f => !f.name.match(/\.(zip|gz)$/i));
     if (invalid.length) {
       this.snack.open('Solo se admiten .zip o .gz', 'OK', { duration: 3000 });
       return;
     }
 
+    await this.svc.requestOutputDirectory();
     this.files.update(o => [...o, ...files]);
     files.forEach(f => this.svc.enqueueDecompress(f));
   }

--- a/src/app/services/compression.service.ts
+++ b/src/app/services/compression.service.ts
@@ -16,15 +16,16 @@ export class CompressionService {
     { type: 'module' }
   );
   private nextId = 0;
+  private outputDir: FileSystemDirectoryHandle | null = null;
   readonly tasks = signal<CompressTask[]>([]);
 
   constructor() {
-    this.worker.onmessage = ({ data }) => {
+    this.worker.onmessage = async ({ data }) => {
       // actualiza barra de progreso
       this.tasks.update(ts => ts.map(t => t.id === data.id ? { ...t, ...data } : t));
 
       if (data.outFile) {
-        saveAs(data.outFile, data.outFile.name);
+        await this.saveFile(data.outFile);
       }
     };
 
@@ -44,5 +45,31 @@ export class CompressionService {
     const task: CompressTask = { id: ++this.nextId, file, progress: 0 };
     this.tasks.update(a => [...a, task]);
     this.worker.postMessage({ ...task, action: 'decompress' });
+  }
+
+  /** Request user to pick an output directory */
+  async requestOutputDirectory() {
+    try {
+      this.outputDir = await (window as any).showDirectoryPicker();
+    } catch (err) {
+      console.warn('Directory picker cancelled or not supported', err);
+      this.outputDir = null;
+    }
+  }
+
+  private async saveFile(file: File) {
+    if (!this.outputDir) {
+      saveAs(file, file.name);
+      return;
+    }
+    try {
+      const handle = await this.outputDir.getFileHandle(file.name, { create: true });
+      const writable = await handle.createWritable();
+      await writable.write(file);
+      await writable.close();
+    } catch (err) {
+      console.error('Failed to write file to directory', err);
+      saveAs(file, file.name);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ask the user for an output directory when unzipping files
- write decompressed files to the selected directory using the File System Access API

## Testing
- `npm install`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_683fee945a608326845b40d7d5ba75b9